### PR TITLE
Add benchmark processing workflow stub

### DIFF
--- a/.github/workflows/process-benchmark-results.yaml
+++ b/.github/workflows/process-benchmark-results.yaml
@@ -1,0 +1,16 @@
+name: process benchmark results
+
+on:
+  repository_dispatch:
+    types: [benchmark_results]
+
+jobs:
+  PROCESS_RESULTS:
+    runs-on: ubuntu-latest
+    steps:
+      - name: parse request
+        shell: bash
+        run: |
+          echo "asset: ${{ github.event.client_payload.asset }}"
+          echo "event: ${{ github.event }}"
+          echo "client_payload: ${{ github.event.client_payload }}"


### PR DESCRIPTION
This PR adds a placeholder workflow file for processing benchmarking results. The workflow contains only a basic debugging step as it needs to be in the default branch to be triggered by the upstream repo via network request/`repository_dispatch`.